### PR TITLE
Add upper limit to react-router dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-swipeable-routes",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Utility for integrating react-swipeable-views with react-router.",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "react": "15.x || 16.x",
-    "react-router": "4.x"
+    "react-router": "4.x <4.4.x"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",


### PR DESCRIPTION
This warns uses if they use a version of `react-router` that is incompatible with this message:
```
npm WARN react-swipeable-routes@0.5.2 requires a peer of react-router@4.x <4.4.x but none is installed. You must install peer dependencies yourself.
```

Closes #17